### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -92,12 +92,21 @@
       {
         "url": "https://api.linear.app/oauth/.*",
         "methods": ["POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingInjections": {
+          "client_id": {
+            "body": ["client_id"]
+          },
+          "client_secret": {
+            "body": ["client_secret"]
+          }
+        }
       },
       {
         "url": "https://api.linear.app/graphql",
         "methods": ["POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingInjections": {}
       }
     ]
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,12 +23,12 @@ export const placeholders = {
   ACCESS_TOKEN: `[user[${ACCESS_TOKEN_PATH}]]`,
   CLIENT_ID: "__client_id__",
   CLIENT_SECRET: "__client_secret__",
-};
+} as const;
 
 export const DESKPRO_LABEL = {
   name: "Deskpro",
   color: lightTheme.colors.brandSecondary,
-};
+} as const;
 
 export const GLOBAL_CLIENT_ID = '84426e34c22e0b0b63eb05f3987fc2d4';
 


### PR DESCRIPTION
This pull request introduces improvements to the configuration and type safety for API integrations and constants. The main changes are the addition of setting injections for OAuth requests in the manifest and enforcing immutability for constants.

**Manifest configuration enhancements:**

* Added a `settingInjections` field to the OAuth API request configuration in `manifest.json`, specifying how `client_id` and `client_secret` should be injected into the request body.
* Added an empty `settingInjections` object to the GraphQL API request configuration for future extensibility.

**Type safety improvements:**

* Marked `placeholders` and `DESKPRO_LABEL` objects as immutable using `as const` in `src/constants.ts`, improving type safety and preventing accidental mutation.

## Summary by Sourcery

Improve proxy configuration and type safety by introducing explicit setting injections in the manifest and enforcing constant immutability.

New Features:
- Add settingInjections configuration for OAuth token requests in manifest.json
- Add placeholder settingInjections object for GraphQL API requests for future extensibility

Enhancements:
- Mark placeholders and DESKPRO_LABEL as immutable with `as const` to strengthen type safety